### PR TITLE
fix: ESM 컨텍스트에서 CJS 타입 선언이 선택되는 문제 수정

### DIFF
--- a/.changeset/fix-esm-type-resolution.md
+++ b/.changeset/fix-esm-type-resolution.md
@@ -1,0 +1,24 @@
+---
+"birecord": patch
+---
+
+Fix ESM type resolution by splitting the `types` condition per entry point
+
+The `exports` map exposed a single top-level `types` condition pointing at
+`dist/mod.d.ts`. Under `moduleResolution: "node16"`/`"nodenext"`, that CJS
+declaration file was selected even when the ESM entry (`dist/mod.mjs`) was
+loaded, so importing the package from an ESM context resolved to a
+CommonJS-flavored module type:
+
+```
+error TS2349: This expression is not callable.
+  Type 'typeof import(".../dist/mod")' has no call signatures.
+```
+
+`dist/mod.d.mts` was already being emitted but was unreachable through
+`exports`. Each condition now carries its own `types`, which fixes the
+`FalseCJS` ("Masquerading as CJS") diagnostic reported by
+`@arethetypeswrong/cli` and the corresponding `publint` warning.
+
+Consumers using `moduleResolution: "bundler"` or `"node"` (node10), or
+requiring the package from CommonJS, are unaffected.

--- a/package.json
+++ b/package.json
@@ -6,9 +6,14 @@
   "types": "./dist/mod.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/mod.d.ts",
-      "require": "./dist/mod.js",
-      "import": "./dist/mod.mjs"
+      "import": {
+        "types": "./dist/mod.d.mts",
+        "default": "./dist/mod.mjs"
+      },
+      "require": {
+        "types": "./dist/mod.d.ts",
+        "default": "./dist/mod.js"
+      }
     }
   },
   "files": [


### PR DESCRIPTION
## 문제

`exports` 맵에 최상위 `types` 조건 하나만 두어 `dist/mod.d.ts`를 가리키고 있었습니다. `moduleResolution`이 `node16`/`nodenext`인 경우, ESM 진입점(`dist/mod.mjs`)을 로드할 때에도 이 CJS 선언 파일이 선택됩니다. 그 결과 ESM에서 패키지를 import하면 default export를 호출할 수 없습니다.

```
consumer.mts(2,11): error TS2349: This expression is not callable.
  Type 'typeof import(".../dist/mod")' has no call signatures.
```

`dist/mod.d.mts`는 이미 생성되고 있었지만 `exports`를 통해 도달할 수 없는 사장(死藏) 파일이었습니다.

이 문제는 publish된 `0.1.1`에도 존재합니다. 새로 생긴 회귀가 아닙니다.

## 수정

각 조건이 자신의 `types`를 갖도록 분리합니다. `main`/`types` 최상위 필드는 node10 폴백용으로 유지합니다.

```diff
   "exports": {
     ".": {
-      "types": "./dist/mod.d.ts",
-      "require": "./dist/mod.js",
-      "import": "./dist/mod.mjs"
+      "import": { "types": "./dist/mod.d.mts", "default": "./dist/mod.mjs" },
+      "require": { "types": "./dist/mod.d.ts", "default": "./dist/mod.js" }
     }
   }
```

## 검증

`npm pack`한 tarball을 실제로 설치해서 측정했습니다.

**`@arethetypeswrong/cli`**

| | 수정 전 | 수정 후 |
|---|---|---|
| node10 | 🟢 | 🟢 |
| node16 (from CJS) | 🟢 | 🟢 |
| node16 (from ESM) | 🎭 Masquerading as CJS | 🟢 (ESM) |
| bundler | 🟢 | 🟢 |

**`publint`**: 경고 1건 → 0건

**TypeScript 매트릭스** (5.0.4 / 5.9.3 / 6.0.3 × 모듈 해석 6조합, 전부 통과)

| module | moduleResolution | 소비 파일 | 수정 전 | 수정 후 |
|---|---|---|---|---|
| commonjs | node | `.ts` | PASS | PASS |
| node16 | node16 | `.ts` | PASS | PASS |
| node16 | node16 | `.mts` | **FAIL (TS2349)** | **PASS** |
| nodenext | nodenext | `.mts` | **FAIL (TS2349)** | **PASS** |
| nodenext | nodenext | `.cts` | PASS | PASS |
| esnext | bundler | `.ts` | PASS | PASS |

기존에 통과하던 조합은 하나도 깨지지 않았습니다.

## 영향 범위

`moduleResolution`이 `bundler` 또는 `node`(node10)인 소비자, CommonJS에서 `require`하는 소비자는 영향을 받지 않습니다. 런타임 해석 경로(`mod.js`, `mod.mjs`)는 변경되지 않았고, 타입 해석만 바뀝니다.

## #6 과의 관계

이 PR은 tsdown 마이그레이션(#6)과 **독립적으로 머지 가능**합니다. `mod.d.mts`는 기존 tsup 빌드에서도 생성되며, 이 브랜치를 tsup 7 + TypeScript 5.1로 빌드해서 attw가 4/4 통과하는 것을 확인했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
